### PR TITLE
fixing simple bugs in read_analysis.py

### DIFF
--- a/src/model_intron_retention.py
+++ b/src/model_intron_retention.py
@@ -36,10 +36,10 @@ def intron_retention(outfile, ref_t):
                 feature_id = info[1]
                 if feature_id not in dict_intron_info:
                     dict_intron_info[feature_id] = []
-        if feature.type == "intron":
-            # feature_id_2 = feature.name.split(':')[1] #feature_id_2 is same as feature_id above if feature is intron, I was just checking and testing it. then removed this line.
-            features[feature.iv] += feature_id
-            dict_intron_info[feature_id].append((feature.iv.start, feature.iv.end, feature.iv.length))
+                    if feature.type == "intron":
+            		    # feature_id_2 = feature.name.split(':')[1] #feature_id_2 is same as feature_id above if feature is intron, I was just checking and testing it. then removed this line.
+            		    features[features.iv] += feature_id
+            		    dict_intron_info[feature_id].append((feature.iv.start, feature.iv.end, feature.iv.length))
 
     #read primary genome alignment for each read
     sys.stdout.write(strftime("%Y-%m-%d %H:%M:%S") + ": Read primary genome alignment for each read\n")

--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -95,7 +95,7 @@ def main():
     t_alnm = args.t_alnm
     outfile = args.output
     num_bins = max(args.num_bins, 20)
-    num_threads = max(args.num_threads, 1)
+    num_threads = max(int(args.num_threads), 1)
 
     if args.no_model_fit:
         model_fit = False
@@ -177,7 +177,7 @@ def main():
     annot_filename, annot_file_extension = os.path.splitext(annot)
     annot_file_extension = annot_file_extension[1:]
     if annot_file_extension.upper() == "GTF":
-        call("gt gtf_to_gff3 -tidy -o " + outfile + ".gff3" + annot, shell=True)
+        call("gt gtf_to_gff3 -tidy -o " + outfile + ".gff3 " + annot, shell=True)
 
     # Next, add intron info into gff3:
     call("gt gff3 -tidy -retainids -checkids -addintrons -o " + outfile + "_addedintron.gff3 " + annot_filename + ".gff3", shell=True)


### PR DESCRIPTION
Changed the type of the argument of num_threads to int. 
Added a missing space in the command for parsing GTF/GFF3 file so that outfile and annot are separated.